### PR TITLE
fix paged responses to allow new schema

### DIFF
--- a/scraper/src/main/kotlin/com/nixops/scraper/tum_api/nat/api/PagedResponse.kt
+++ b/scraper/src/main/kotlin/com/nixops/scraper/tum_api/nat/api/PagedResponse.kt
@@ -1,7 +1,9 @@
 package com.nixops.scraper.tum_api.nat.api
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.fasterxml.jackson.annotation.JsonProperty
 
+@JsonIgnoreProperties(ignoreUnknown = true)
 data class PagedResponse<T>(
     @JsonProperty("hits") val hits: List<T>,
     @JsonProperty("count") val count: Int,


### PR DESCRIPTION
The NAT API changed the paged response to contain a prev_offset. We can simply ignore it