### PR TITLE
Fix: use correct ports in configmaps

### DIFF
--- a/helm/templates/schedule-manager/schedule-manager-configmap.yaml
+++ b/helm/templates/schedule-manager/schedule-manager-configmap.yaml
@@ -39,7 +39,7 @@ data:
     }
     prometheus.scrape "default" {
       targets = [{
-        __address__ = "127.0.0.1:8040",
+        __address__ = "127.0.0.1:8042",
       }]
       metrics_path    = "/metrics"
       forward_to = [prometheus.remote_write.default.receiver]

--- a/helm/templates/scraper/scraper-configmap.yaml
+++ b/helm/templates/scraper/scraper-configmap.yaml
@@ -39,7 +39,7 @@ data:
     }
     prometheus.scrape "default" {
       targets = [{
-        __address__ = "127.0.0.1:8000",
+        __address__ = "127.0.0.1:8080",
       }]
       metrics_path    = "/metrics"
       forward_to = [prometheus.remote_write.default.receiver]


### PR DESCRIPTION
The schedule-manager and embedding-bridge monitoring configmaps had the wrong ports configured