### PR TITLE
Fix: fix swagger-ui for scraper and schedule-manager docker images

### DIFF
--- a/schedule-manager/build.gradle.kts
+++ b/schedule-manager/build.gradle.kts
@@ -125,6 +125,8 @@ tasks.register<org.openapitools.generator.gradle.plugin.tasks.GenerateTask>(
           ))
     }
 
+tasks.processResources { from("$projectDir/openapi.yaml") { into(".") } }
+
 tasks.test { useJUnitPlatform() }
 
 tasks.named("compileKotlin") {

--- a/schedule-manager/src/main/kotlin/com/nixops/schedulemanager/controller/OpenApiSpecController.kt
+++ b/schedule-manager/src/main/kotlin/com/nixops/schedulemanager/controller/OpenApiSpecController.kt
@@ -1,8 +1,8 @@
 package com.nixops.schedulemanager.controller
 
-import java.io.File
-import org.springframework.core.io.FileSystemResource
+import org.springframework.core.io.ClassPathResource
 import org.springframework.core.io.Resource
+import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 
@@ -10,9 +10,12 @@ import org.springframework.web.bind.annotation.RestController
 class OpenApiSpecController {
 
   @RequestMapping("/api-docs.yaml", produces = ["application/yaml"])
-  fun getOpenApiYaml(): Resource {
-    val file = File("openapi.yaml")
-    println("Trying to serve: ${file.absolutePath} exists: ${file.exists()}")
-    return FileSystemResource(file)
+  fun getOpenApiYaml(): ResponseEntity<Resource> {
+    val resource = ClassPathResource("openapi.yaml")
+    return if (resource.exists()) {
+      ResponseEntity.ok(resource)
+    } else {
+      ResponseEntity.notFound().build()
+    }
   }
 }

--- a/scraper/build.gradle.kts
+++ b/scraper/build.gradle.kts
@@ -94,6 +94,8 @@ tasks.openApiGenerate {
   skipValidateSpec.set(true)
 }
 
+tasks.processResources { from("$projectDir/openapi.yaml") { into(".") } }
+
 tasks.named("compileKotlin") { dependsOn("openApiGenerate") }
 
 tasks.test { useJUnitPlatform { excludeTags("remoteApi") } }

--- a/scraper/src/main/kotlin/com/nixops/scraper/controller/OpenApiSpecController.kt
+++ b/scraper/src/main/kotlin/com/nixops/scraper/controller/OpenApiSpecController.kt
@@ -1,8 +1,8 @@
 package com.nixops.scraper.controller
 
-import java.io.File
-import org.springframework.core.io.FileSystemResource
+import org.springframework.core.io.ClassPathResource
 import org.springframework.core.io.Resource
+import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 
@@ -10,9 +10,12 @@ import org.springframework.web.bind.annotation.RestController
 class OpenApiSpecController {
 
   @RequestMapping("/api-docs.yaml", produces = ["application/yaml"])
-  fun getOpenApiYaml(): Resource {
-    val file = File("openapi.yaml")
-    println("Trying to serve: ${file.absolutePath} exists: ${file.exists()}")
-    return FileSystemResource(file)
+  fun getOpenApiYaml(): ResponseEntity<Resource> {
+    val resource = ClassPathResource("openapi.yaml")
+    return if (resource.exists()) {
+      ResponseEntity.ok(resource)
+    } else {
+      ResponseEntity.notFound().build()
+    }
   }
 }


### PR DESCRIPTION
Fixed the Swagger-UI for the scraper and schedule-manager docker images by bundling the openapi.yaml in the jar